### PR TITLE
US49 - Registrar resposta de formulário na API 

### DIFF
--- a/src/api/coordinator.js
+++ b/src/api/coordinator.js
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import Coordinator from '../models/coordinator'
+import Answer from '../models/answer'
 import { getCorrectError } from '../helpers/errorHandling'
 import _ from 'lodash'
 
@@ -168,6 +169,34 @@ export default ({ config, db }) => {
         response.status(statusError).json({ error: errorMessage })
       }
     })
+
+    router.post('/:coordinator/answer/:form',
+      async ({ coordinator, params, body }, response) => {
+        var success = false
+        try {
+          var answerInstance = await Answer.save(body.answer)
+
+          await answerInstance.addRelation("form", { id: params.form })
+          await answerInstance.addRelation("coordinator", { registration: coordinator.registration })
+
+          success = true 
+          response.json({ success })
+        } catch (error) {
+            console.log(error)
+            var errorMessage = getCorrectError(error,
+            error.name,
+            "Coordenador não encontrado",
+            "Dados inválidos de coordenador " + error.message
+          )
+
+          var statusError = getCorrectError(error,
+            404,
+            404,
+            400
+          )
+          response.status(statusError).json({ error: errorMessage, success })
+        }
+      })
 
   return router
 }

--- a/src/api/coordinator.js
+++ b/src/api/coordinator.js
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import Coordinator from '../models/coordinator'
 import Answer from '../models/answer'
+import Form from '../models/form'
 import { getCorrectError } from '../helpers/errorHandling'
 import _ from 'lodash'
 
@@ -175,15 +176,15 @@ export default ({ config, db }) => {
         var success = false
         try {
           var coordinatorInstance = await coordinator
+          var formInstance = await Form.get(params.form)
           var answerInstance = await Answer.save(body.answer)
-          var result = await answerInstance.addRelation("form", { id: params.form })
+
+          var result = await answerInstance.addRelation("form", { id: formInstance.id })
           result = await answerInstance.addRelation("coordinator", { registration: coordinatorInstance.registration })
-          // var result = await coordinator.getJoin({forums: true, answers: true}).run()
 
           success = true
           response.json({ result, success })
         } catch (error) {
-            console.log(error)
             var errorMessage = getCorrectError(error,
             error.name,
             "Coordenador não encontrado",

--- a/src/api/coordinator.js
+++ b/src/api/coordinator.js
@@ -174,13 +174,14 @@ export default ({ config, db }) => {
       async ({ coordinator, params, body }, response) => {
         var success = false
         try {
+          var coordinatorInstance = await coordinator
           var answerInstance = await Answer.save(body.answer)
+          var result = await answerInstance.addRelation("form", { id: params.form })
+          result = await answerInstance.addRelation("coordinator", { registration: coordinatorInstance.registration })
+          // var result = await coordinator.getJoin({forums: true, answers: true}).run()
 
-          await answerInstance.addRelation("form", { id: params.form })
-          await answerInstance.addRelation("coordinator", { registration: coordinator.registration })
-
-          success = true 
-          response.json({ success })
+          success = true
+          response.json({ result, success })
         } catch (error) {
             console.log(error)
             var errorMessage = getCorrectError(error,

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -1,0 +1,21 @@
+import { thinky, type } from '../db'
+import Form from './form'
+import Coordinator from './coordinator'
+
+var Answer = thinky.createModel('Answer', {
+    discursiveAnswers: [{
+        question: type.string(),
+        answer: type.string()
+    }],
+    multipleChoiceAnswers: [{
+        question: type.string(),
+        answers: [type.string()]
+    }]
+})
+
+Coordinator.hasMany(Answer, 'answer', 'registration', 'id')
+Answer.belongsTo(Coordinator, 'coordinators', 'id', 'registration')
+Form.hasMany(Answer, 'answer', 'id', 'id')
+Answer.belongsTo(Form, 'forms', 'id', 'id')
+
+export default Answer

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -13,9 +13,9 @@ var Answer = thinky.createModel('Answer', {
     }]
 })
 
-Coordinator.hasMany(Answer, 'answer', 'registration', 'id')
-Answer.belongsTo(Coordinator, 'coordinators', 'id', 'registration')
-Form.hasMany(Answer, 'answer', 'id', 'id')
-Answer.belongsTo(Form, 'forms', 'id', 'id')
+Coordinator.hasMany(Answer, 'answers', 'registration', 'id')
+Answer.belongsTo(Coordinator, 'coordinator', 'id', 'registration')
+Form.hasMany(Answer, 'answers', 'id', 'id')
+Answer.belongsTo(Form, 'form', 'id', 'id')
 
 export default Answer

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -10,12 +10,14 @@ var Answer = thinky.createModel('Answer', {
     multipleChoiceAnswers: [{
         question: type.string(),
         answers: [type.string()]
-    }]
+    }],
+    formId: type.string(),
+    coordinatorRegistration: type.string()
 })
 
-Coordinator.hasMany(Answer, 'answers', 'registration', 'id')
-Answer.belongsTo(Coordinator, 'coordinator', 'id', 'registration')
-Form.hasMany(Answer, 'answers', 'id', 'id')
-Answer.belongsTo(Form, 'form', 'id', 'id')
+Coordinator.hasMany(Answer, 'answers', 'registration', 'coordinatorRegistration')
+Answer.belongsTo(Coordinator, 'coordinator', 'coordinatorRegistration', 'registration')
+Form.hasMany(Answer, 'answers', 'id', 'formId')
+Answer.belongsTo(Form, 'form', 'formId', 'id')
 
 export default Answer

--- a/src/test/coordinator.js
+++ b/src/test/coordinator.js
@@ -227,5 +227,107 @@ describe("Coordinator Tests", function () {
       })
     })
 
+    it('it should post a coordinator\'s answer to a form', (done) => {
+      let answer = {
+        answer: {
+          discursiveAnswers: [
+            {
+              question: "questão",
+              answer: "resposta"
+            }
+          ],
+          multipleChoiceAnswers: [
+            {
+              question: "outra questão",
+              answers: [ "uma opção", "outra opção"]
+            },
+            {
+              question: "mais uma questão",
+              answers: ["só essa opção"]
+            }
+          ]
+        }
+      }
+
+      chai.request(runningServer)
+      .post('/api/coordinators/123456789/answer/1')
+      .send(answer)
+      .end((err, res) => {
+        res.should.have.status(200)
+        res.body.result.should.have.property('coordinatorRegistration')
+        res.body.result.should.have.property('formId')
+        res.body.result.should.have.property('discursiveAnswers')
+        res.body.result.should.have.property('multipleChoiceAnswers')
+        res.body.success.should.be.eql(true)
+        done()
+      })
+    })
+
+    it('it should not post a coordinator\'s answer to a form given the coordinator is not registered', (done) => {
+      let answer = {
+        answer: {
+          discursiveAnswers: [
+            {
+              question: "questão",
+              answer: "resposta"
+            }
+          ],
+          multipleChoiceAnswers: [
+            {
+              question: "outra questão",
+              answers: [ "uma opção", "outra opção"]
+            },
+            {
+              question: "mais uma questão",
+              answers: ["só essa opção"]
+            }
+          ]
+        }
+      }
+
+      chai.request(runningServer)
+      .post('/api/coordinators/123/answer/1')
+      .send(answer)
+      .end((err, res) => {
+        res.should.have.status(404)
+        res.body.should.have.property('error')
+        res.body.success.should.be.eql(false)
+        done()
+      })
+    })
+
+    it('it should not post a coordinator\'s answer to a form given the form id is invalid', (done) => {
+      let answer = {
+        answer: {
+          discursiveAnswers: [
+            {
+              question: "questão",
+              answer: "resposta"
+            }
+          ],
+          multipleChoiceAnswers: [
+            {
+              question: "outra questão",
+              answers: [ "uma opção", "outra opção"]
+            },
+            {
+              question: "mais uma questão",
+              answers: ["só essa opção"]
+            }
+          ]
+        }
+      }
+
+      chai.request(runningServer)
+      .post('/api/coordinators/123456789/answer/123')
+      .send(answer)
+      .end((err, res) => {
+        res.should.have.status(404)
+        res.body.should.have.property('error')
+        res.body.success.should.be.eql(false)
+        done()
+      })
+    })
+
   })
 })


### PR DESCRIPTION
Este pull request habilita a manipulação de respostas de formulários na API.  
Rota criada:  
**/api/coordinators/:registration/answer/:formId** - POST para resposta.